### PR TITLE
Add admin pages and chat store

### DIFF
--- a/app/chats/[id]/page.tsx
+++ b/app/chats/[id]/page.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { useChatStore } from "@/lib/stores/useChatStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { ArrowLeft, Send } from "lucide-react"
+
+export default function ChatDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const chatId = params.id as string
+
+  const { messages, isLoading, fetchMessages, sendMessage } = useChatStore()
+  const [text, setText] = useState("")
+
+  useEffect(() => {
+    if (chatId) {
+      fetchMessages(chatId)
+    }
+  }, [chatId, fetchMessages])
+
+  const handleSend = async () => {
+    if (text.trim()) {
+      await sendMessage(chatId, text)
+      setText("")
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Chat</h1>
+            <p className="text-muted-foreground">Mensajes con el cliente o repartidor</p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Mensajes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {messages.map((msg) => (
+                <div key={msg.id} className="border p-2 rounded-md">
+                  <p className="text-sm">{msg.clientext || msg.ridertext || msg.admintext}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(msg.timestamp as unknown as string).toLocaleString()}
+                  </p>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex items-center gap-2">
+              <Input value={text} onChange={(e) => setText(e.target.value)} placeholder="Escribe un mensaje" />
+              <Button type="button" onClick={handleSend} size="icon">
+                <Send className="h-4 w-4" />
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/chats/page.tsx
+++ b/app/chats/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import type { ColumnDef } from "@tanstack/react-table"
+import { useChatStore } from "@/lib/stores/useChatStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { DataTable } from "@/components/ui/data-table"
+import { Button } from "@/components/ui/button"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { Eye } from "lucide-react"
+import type { Chat } from "@/lib/types"
+
+const columns: ColumnDef<Chat>[] = [
+  {
+    accessorKey: "chatnumber",
+    header: "Chat",
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const chat = row.original
+      return (
+        <Button variant="ghost" size="icon" asChild>
+          <Link href={`/chats/${chat.id}`}>
+            <Eye className="h-4 w-4" />
+          </Link>
+        </Button>
+      )
+    },
+  },
+]
+
+export default function ChatsPage() {
+  const { chats, isLoading, fetchChats } = useChatStore()
+
+  useEffect(() => {
+    fetchChats()
+  }, [fetchChats])
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Chats</h1>
+          <p className="text-muted-foreground">Conversaciones entre clientes y riders</p>
+        </div>
+        <DataTable columns={columns} data={chats} searchKey="chatnumber" searchPlaceholder="Buscar por número..." />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,0 +1,13 @@
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+
+export default function DocumentsPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Documentos</h1>
+        <p className="text-muted-foreground">Gestión de verificación de documentos</p>
+        <p>Página en construcción.</p>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/restaurants/[id]/page.tsx
+++ b/app/restaurants/[id]/page.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import { useEffect } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { useRestaurantStore } from "@/lib/stores/useRestaurantStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { ArrowLeft } from "lucide-react"
+
+export default function RestaurantDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const restaurantId = params.id as string
+
+  const { currentRestaurant, isLoading, fetchRestaurantById } = useRestaurantStore()
+
+  useEffect(() => {
+    if (restaurantId) {
+      fetchRestaurantById(restaurantId)
+    }
+  }, [restaurantId, fetchRestaurantById])
+
+  if (isLoading || !currentRestaurant) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">{currentRestaurant.name}</h1>
+            <p className="text-muted-foreground">Información del restaurante</p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Datos Generales</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Ciudad:</span>
+              <span className="text-sm">{currentRestaurant.city}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Dirección:</span>
+              <span className="text-sm">{currentRestaurant.addressText}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Encargado:</span>
+              <span className="text-sm">{currentRestaurant.managerName}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Activo:</span>
+              <Badge variant={currentRestaurant.isActive ? "default" : "secondary"}>
+                {currentRestaurant.isActive ? "Sí" : "No"}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/restaurants/page.tsx
+++ b/app/restaurants/page.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import type { ColumnDef } from "@tanstack/react-table"
+import { useRestaurantStore } from "@/lib/stores/useRestaurantStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { DataTable } from "@/components/ui/data-table"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { Eye } from "lucide-react"
+import type { Restaurant } from "@/lib/types"
+
+const columns: ColumnDef<Restaurant>[] = [
+  {
+    accessorKey: "name",
+    header: "Nombre",
+    cell: ({ row }) => <div className="font-medium">{row.getValue("name")}</div>,
+  },
+  {
+    accessorKey: "city",
+    header: "Ciudad",
+  },
+  {
+    accessorKey: "managerName",
+    header: "Encargado",
+  },
+  {
+    accessorKey: "isActive",
+    header: "Activo",
+    cell: ({ row }) => (
+      <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
+    ),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const restaurant = row.original
+      return (
+        <Button variant="ghost" size="icon" asChild>
+          <Link href={`/restaurants/${restaurant.id}`}>
+            <Eye className="h-4 w-4" />
+          </Link>
+        </Button>
+      )
+    },
+  },
+]
+
+export default function RestaurantsPage() {
+  const { restaurants, isLoading, fetchRestaurants } = useRestaurantStore()
+
+  useEffect(() => {
+    fetchRestaurants()
+  }, [fetchRestaurants])
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Restaurantes</h1>
+          <p className="text-muted-foreground">Administración de restaurantes registrados</p>
+        </div>
+        <DataTable columns={columns} data={restaurants} searchKey="name" searchPlaceholder="Buscar por nombre..." />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/riders/[id]/page.tsx
+++ b/app/riders/[id]/page.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { useEffect } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { useRiderStore } from "@/lib/stores/useRiderStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { ArrowLeft } from "lucide-react"
+
+export default function RiderDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const riderId = params.id as string
+
+  const { currentRider, isLoading, fetchRiderById } = useRiderStore()
+
+  useEffect(() => {
+    if (riderId) {
+      fetchRiderById(riderId)
+    }
+  }, [riderId, fetchRiderById])
+
+  if (isLoading || !currentRider) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">{currentRider.display_name}</h1>
+            <p className="text-muted-foreground">Perfil del repartidor</p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Información</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Teléfono:</span>
+              <span className="text-sm">{currentRider.phone}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Usuario:</span>
+              <span className="text-sm">{currentRider.user_name}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Activo:</span>
+              <Badge variant={currentRider.isActive ? "default" : "secondary"}>
+                {currentRider.isActive ? "Sí" : "No"}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/riders/page.tsx
+++ b/app/riders/page.tsx
@@ -1,0 +1,79 @@
+"use client"
+
+import { useEffect } from "react"
+import Link from "next/link"
+import type { ColumnDef } from "@tanstack/react-table"
+import { useRiderStore } from "@/lib/stores/useRiderStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { DataTable } from "@/components/ui/data-table"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { Eye } from "lucide-react"
+import type { Rider } from "@/lib/types"
+
+const columns: ColumnDef<Rider>[] = [
+  {
+    accessorKey: "display_name",
+    header: "Nombre",
+    cell: ({ row }) => <div className="font-medium">{row.getValue("display_name")}</div>,
+  },
+  {
+    accessorKey: "phone",
+    header: "Teléfono",
+  },
+  {
+    accessorKey: "user_name",
+    header: "Usuario",
+  },
+  {
+    accessorKey: "isActive",
+    header: "Activo",
+    cell: ({ row }) => (
+      <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
+    ),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const rider = row.original
+      return (
+        <Button variant="ghost" size="icon" asChild>
+          <Link href={`/riders/${rider.id}`}>
+            <Eye className="h-4 w-4" />
+          </Link>
+        </Button>
+      )
+    },
+  },
+]
+
+export default function RidersPage() {
+  const { riders, isLoading, fetchRiders } = useRiderStore()
+
+  useEffect(() => {
+    fetchRiders()
+  }, [fetchRiders])
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Repartidores</h1>
+          <p className="text-muted-foreground">Lista de repartidores registrados</p>
+        </div>
+        <DataTable columns={columns} data={riders} searchKey="display_name" searchPlaceholder="Buscar por nombre..." />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,13 @@
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+
+export default function StatsPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <h1 className="text-3xl font-bold tracking-tight">Estadísticas</h1>
+        <p className="text-muted-foreground">Métricas avanzadas de la plataforma</p>
+        <p>Página en construcción.</p>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -1,0 +1,10 @@
+export default function UnauthorizedPage() {
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <div className="text-center space-y-4">
+        <h1 className="text-3xl font-bold">Acceso denegado</h1>
+        <p className="text-muted-foreground">No tienes permisos para acceder a esta sección.</p>
+      </div>
+    </div>
+  )
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { useEffect } from "react"
+import type { ColumnDef } from "@tanstack/react-table"
+import { useUserStore } from "@/lib/stores/useUserStore"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { DataTable } from "@/components/ui/data-table"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import type { User } from "@/lib/types"
+
+const columns: ColumnDef<User>[] = [
+  {
+    accessorKey: "display_name",
+    header: "Nombre",
+    cell: ({ row }) => <div className="font-medium">{row.getValue("display_name")}</div>,
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+  },
+  {
+    accessorKey: "role",
+    header: "Rol",
+    cell: ({ row }) => <Badge variant="outline">{row.getValue("role")}</Badge>,
+  },
+  {
+    accessorKey: "isActive",
+    header: "Activo",
+    cell: ({ row }) => (
+      <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
+    ),
+  },
+]
+
+export default function UsersPage() {
+  const { users, isLoading, fetchUsers } = useUserStore()
+
+  useEffect(() => {
+    fetchUsers()
+  }, [fetchUsers])
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Usuarios</h1>
+          <p className="text-muted-foreground">Listado completo de usuarios registrados</p>
+        </div>
+        <DataTable columns={columns} data={users} searchKey="display_name" searchPlaceholder="Buscar por nombre..." />
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/lib/services/chatService.ts
+++ b/lib/services/chatService.ts
@@ -1,6 +1,23 @@
-import { collection, getDocs, query, where, addDoc, orderBy } from "firebase/firestore"
+import {
+  collection,
+  getDocs,
+  query,
+  where,
+  addDoc,
+  orderBy,
+} from "firebase/firestore"
 import { db } from "../firebase"
 import type { Chat, Message } from "../types"
+
+export const getAllChats = async (): Promise<Chat[]> => {
+  try {
+    const snapshot = await getDocs(collection(db, "chat"))
+    return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }) as Chat)
+  } catch (error) {
+    console.error("Error fetching chats:", error)
+    return []
+  }
+}
 
 export const getChatByOrderId = async (orderId: string): Promise<Chat | null> => {
   try {

--- a/lib/stores/useChatStore.ts
+++ b/lib/stores/useChatStore.ts
@@ -1,0 +1,82 @@
+import { create } from "zustand"
+import { getAllChats, getChatByOrderId, getMessagesByChat, sendAdminMessage } from "../services/chatService"
+import type { Chat, Message } from "../types"
+
+interface ChatState {
+  chats: Chat[]
+  currentChat: Chat | null
+  messages: Message[]
+  isLoading: boolean
+  error: string | null
+  fetchChats: () => Promise<void>
+  fetchChatByOrder: (orderId: string) => Promise<void>
+  fetchMessages: (chatId: string) => Promise<void>
+  sendMessage: (chatId: string, text: string) => Promise<boolean>
+}
+
+export const useChatStore = create<ChatState>((set) => ({
+  chats: [],
+  currentChat: null,
+  messages: [],
+  isLoading: false,
+  error: null,
+
+  fetchChats: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const chats = await getAllChats()
+      set({ chats, isLoading: false })
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Error al cargar chats",
+        isLoading: false,
+      })
+    }
+  },
+
+  fetchChatByOrder: async (orderId: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const chat = await getChatByOrderId(orderId)
+      set({ currentChat: chat, isLoading: false })
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Error al cargar el chat",
+        isLoading: false,
+      })
+    }
+  },
+
+  fetchMessages: async (chatId: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const messages = await getMessagesByChat(chatId)
+      set({ messages, isLoading: false })
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Error al cargar mensajes",
+        isLoading: false,
+      })
+    }
+  },
+
+  sendMessage: async (chatId: string, text: string) => {
+    set({ isLoading: true, error: null })
+    try {
+      const success = await sendAdminMessage(chatId, text)
+      if (success) {
+        const messages = await getMessagesByChat(chatId)
+        set({ messages, isLoading: false })
+      } else {
+        set({ isLoading: false })
+      }
+      return success
+    } catch (error) {
+      set({
+        error: error instanceof Error ? error.message : "Error al enviar mensaje",
+        isLoading: false,
+      })
+      return false
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- add getAllChats service
- create chat Zustand store
- implement riders, restaurants, users and chats pages
- add detail pages for riders and restaurants
- add placeholder pages for documents, stats and unauthorized access

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6845f80353d8832fad76f3ca79a5c943