### PR TITLE
Fix rider active status and details

### DIFF
--- a/app/riders/[id]/page.tsx
+++ b/app/riders/[id]/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import { ArrowLeft, User, Phone, Mail } from "lucide-react"
+import { ArrowLeft, User, Phone, Mail, Check, X } from "lucide-react"
 
 export default function RiderDetailPage() {
   const params = useParams()
@@ -86,8 +86,16 @@ export default function RiderDetailPage() {
             
             <div className="flex justify-between items-center">
               <span className="text-sm font-medium">Estado:</span>
-              <Badge variant={currentRider.isActive ? "default" : "secondary"}>
-                {currentRider.isActive ? "Activo" : "Inactivo"}
+              <Badge
+                variant={currentRider.active_rider ? "default" : "secondary"}
+                className="flex items-center gap-1"
+              >
+                {currentRider.active_rider ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <X className="h-3 w-3" />
+                )}
+                {currentRider.active_rider ? "Sí" : "No"}
               </Badge>
             </div>
 
@@ -161,13 +169,31 @@ export default function RiderDetailPage() {
                   Entregas totales
                 </div>
               </div>
-              
+
               <div className="text-center p-4 bg-muted rounded-lg">
                 <div className="text-2xl font-bold">
                   {currentRider.rating ? `${currentRider.rating}/5` : 'N/A'}
                 </div>
                 <div className="text-sm text-muted-foreground">
                   Calificación
+                </div>
+              </div>
+
+              <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-2xl font-bold">
+                  {currentRider.active_orders || 0}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Pedidos activos
+                </div>
+              </div>
+
+              <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-2xl font-bold">
+                  {currentRider.number_deliverys || 0}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Entregas realizadas
                 </div>
               </div>
             </div>

--- a/app/riders/page.tsx
+++ b/app/riders/page.tsx
@@ -9,7 +9,7 @@ import { DataTable } from "@/components/ui/data-table"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import { Eye } from "lucide-react"
+import { Eye, Check, X } from "lucide-react"
 import type { Rider } from "@/lib/types"
 
 const columns: ColumnDef<Rider>[] = [
@@ -27,10 +27,20 @@ const columns: ColumnDef<Rider>[] = [
     header: "Usuario",
   },
   {
-    accessorKey: "isActive",
+    accessorKey: "active_rider",
     header: "Activo",
     cell: ({ row }) => (
-      <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
+      <Badge
+        variant={row.getValue("active_rider") ? "default" : "secondary"}
+        className="flex items-center gap-1"
+      >
+        {row.getValue("active_rider") ? (
+          <Check className="h-3 w-3" />
+        ) : (
+          <X className="h-3 w-3" />
+        )}
+        {row.getValue("active_rider") ? "Sí" : "No"}
+      </Badge>
     ),
   },
   {

--- a/lib/services/dashboardService.ts
+++ b/lib/services/dashboardService.ts
@@ -13,8 +13,8 @@ export const getDashboardStats = async (): Promise<DashboardStats> => {
     const activeOrdersSnapshot = await getDocs(activeOrdersQuery)
     const activeOrders = activeOrdersSnapshot.size
 
-    // Get connected riders (assuming riders with isActive=true are connected)
-    const connectedRidersQuery = query(collection(db, "rider"), where("isActive", "==", true))
+    // Get connected riders (assuming riders with active_rider=true are connected)
+    const connectedRidersQuery = query(collection(db, "rider"), where("active_rider", "==", true))
     const connectedRidersSnapshot = await getDocs(connectedRidersQuery)
     const connectedRiders = connectedRidersSnapshot.size
 

--- a/lib/services/riderService.ts
+++ b/lib/services/riderService.ts
@@ -27,7 +27,7 @@ export const getAllRiders = async (): Promise<Rider[]> => {
 
 export const getActiveRiders = async (): Promise<Rider[]> => {
   try {
-    const q = query(collection(db, "rider"), where("isActive", "==", true))
+    const q = query(collection(db, "rider"), where("active_rider", "==", true))
     const ridersSnapshot = await getDocs(q)
     return ridersSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }) as Rider)
   } catch (error) {

--- a/lib/stores/useRiderStore.ts
+++ b/lib/stores/useRiderStore.ts
@@ -82,8 +82,8 @@ export const useRiderStore = create<RiderState>((set) => ({
               : state.currentRider,
           riders: state.riders.map((r) => (r.id === id ? { ...r, ...data } : r)),
           activeRiders:
-            data.isActive !== undefined
-              ? data.isActive
+            data.active_rider !== undefined
+              ? data.active_rider
                 ? [...state.activeRiders, state.riders.find((r) => r.id === id)!].filter(Boolean)
                 : state.activeRiders.filter((r) => r.id !== id)
               : state.activeRiders,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,9 @@ export interface Rider {
   photo_url: string
   user_name: string
   user_ref: DocumentReference
-  isActive?: boolean
+  active_rider: boolean
+  active_orders?: number
+  number_deliverys?: number
 }
 
 export interface Restaurant {


### PR DESCRIPTION
## Summary
- show active rider status correctly in rider list and detail pages
- add active rider info in Rider type
- adjust stores and services to use `active_rider`
- display rider statistics for active orders and deliveries

## Testing
- `pnpm install` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684720445948832fadaaafc737aba2d3