### PR TITLE
Add user detail view

### DIFF
--- a/app/riders/[id]/page.tsx
+++ b/app/riders/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useParams, useRouter } from "next/navigation"
 import { useRiderStore } from "@/lib/stores/useRiderStore"
 import { useUserStore } from "@/lib/stores/useUserStore"
@@ -9,15 +9,37 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import { ArrowLeft, User, Phone, Mail } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { toast } from "sonner"
+import { ArrowLeft, User, Phone, Mail, Check, X } from "lucide-react"
 
 export default function RiderDetailPage() {
   const params = useParams()
   const router = useRouter()
   const riderId = params.id as string
 
-  const { currentRider, isLoading, fetchRiderById } = useRiderStore()
+  const { currentRider, isLoading, fetchRiderById, updateRiderData } = useRiderStore()
   const { currentUser, fetchUserById } = useUserStore()
+
+  const [editOpen, setEditOpen] = useState(false)
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [editData, setEditData] = useState({
+    display_name: "",
+    phone: "",
+    user_name: "",
+    active_rider: false,
+    photo_url: "",
+  })
 
   useEffect(() => {
     if (riderId) {
@@ -38,6 +60,31 @@ export default function RiderDetailPage() {
     }
   }, [currentRider, fetchUserById])
 
+  useEffect(() => {
+    if (currentRider) {
+      setEditData({
+        display_name: currentRider.display_name,
+        phone: currentRider.phone,
+        user_name: currentRider.user_name,
+        active_rider: currentRider.active_rider,
+        photo_url: currentRider.photo_url,
+      })
+    }
+  }, [currentRider])
+
+  const handleUpdate = async () => {
+    setIsUpdating(true)
+    const success = await updateRiderData(riderId, editData)
+    if (success) {
+      toast.success("Repartidor actualizado correctamente")
+      setEditOpen(false)
+      fetchRiderById(riderId)
+    } else {
+      toast.error("Error al actualizar el repartidor")
+    }
+    setIsUpdating(false)
+  }
+
   if (isLoading || !currentRider) {
     return (
       <DashboardLayout>
@@ -52,14 +99,17 @@ export default function RiderDetailPage() {
     <DashboardLayout>
       <div className="space-y-6">
         {/* Header Section */}
-        <div className="flex items-center gap-4">
-          <Button variant="outline" size="icon" onClick={() => router.back()}>
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{currentRider.display_name}</h1>
-            <p className="text-muted-foreground">Perfil del repartidor</p>
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-4">
+            <Button variant="outline" size="icon" onClick={() => router.back()}>
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <div>
+              <h1 className="text-3xl font-bold tracking-tight">{currentRider.display_name}</h1>
+              <p className="text-muted-foreground">Perfil del repartidor</p>
+            </div>
           </div>
+          <Button onClick={() => setEditOpen(true)}>Editar</Button>
         </div>
 
         {/* Rider Information Card */}
@@ -86,8 +136,16 @@ export default function RiderDetailPage() {
             
             <div className="flex justify-between items-center">
               <span className="text-sm font-medium">Estado:</span>
-              <Badge variant={currentRider.isActive ? "default" : "secondary"}>
-                {currentRider.isActive ? "Activo" : "Inactivo"}
+              <Badge
+                variant={currentRider.active_rider ? "default" : "secondary"}
+                className="flex items-center gap-1"
+              >
+                {currentRider.active_rider ? (
+                  <Check className="h-3 w-3" />
+                ) : (
+                  <X className="h-3 w-3" />
+                )}
+                {currentRider.active_rider ? "Sí" : "No"}
               </Badge>
             </div>
 
@@ -161,13 +219,31 @@ export default function RiderDetailPage() {
                   Entregas totales
                 </div>
               </div>
-              
+
               <div className="text-center p-4 bg-muted rounded-lg">
                 <div className="text-2xl font-bold">
                   {currentRider.rating ? `${currentRider.rating}/5` : 'N/A'}
                 </div>
                 <div className="text-sm text-muted-foreground">
                   Calificación
+                </div>
+              </div>
+
+              <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-2xl font-bold">
+                  {currentRider.active_orders || 0}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Pedidos activos
+                </div>
+              </div>
+
+              <div className="text-center p-4 bg-muted rounded-lg">
+                <div className="text-2xl font-bold">
+                  {currentRider.number_deliverys || 0}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Entregas realizadas
                 </div>
               </div>
             </div>
@@ -182,6 +258,81 @@ export default function RiderDetailPage() {
             )}
           </CardContent>
         </Card>
+
+        {/* Edit Rider Dialog */}
+        <Dialog open={editOpen} onOpenChange={setEditOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Editar repartidor</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="display_name">Nombre</Label>
+                <Input
+                  id="display_name"
+                  value={editData.display_name}
+                  onChange={(e) =>
+                    setEditData({ ...editData, display_name: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="phone">Teléfono</Label>
+                <Input
+                  id="phone"
+                  value={editData.phone}
+                  onChange={(e) =>
+                    setEditData({ ...editData, phone: e.target.value })
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="user_name">Usuario</Label>
+                <Input
+                  id="user_name"
+                  value={editData.user_name}
+                  onChange={(e) =>
+                    setEditData({ ...editData, user_name: e.target.value })
+                  }
+                />
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  checked={editData.active_rider}
+                  onCheckedChange={(value) =>
+                    setEditData({ ...editData, active_rider: value })
+                  }
+                />
+                <span className="text-sm">Activo</span>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="photo_url">Foto (URL)</Label>
+                {editData.photo_url && (
+                  <img
+                    src={editData.photo_url}
+                    alt="Foto de perfil"
+                    className="h-24 w-24 object-cover rounded-md"
+                  />
+                )}
+                <Input
+                  id="photo_url"
+                  value={editData.photo_url}
+                  onChange={(e) =>
+                    setEditData({ ...editData, photo_url: e.target.value })
+                  }
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline">Cancelar</Button>
+              </DialogClose>
+              <Button onClick={handleUpdate} disabled={isUpdating}>
+                {isUpdating ? "Guardando..." : "Guardar cambios"}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
     </DashboardLayout>
   )

--- a/app/riders/page.tsx
+++ b/app/riders/page.tsx
@@ -9,7 +9,7 @@ import { DataTable } from "@/components/ui/data-table"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import { Eye } from "lucide-react"
+import { Eye, Check, X } from "lucide-react"
 import type { Rider } from "@/lib/types"
 
 const columns: ColumnDef<Rider>[] = [
@@ -27,10 +27,20 @@ const columns: ColumnDef<Rider>[] = [
     header: "Usuario",
   },
   {
-    accessorKey: "isActive",
+    accessorKey: "active_rider",
     header: "Activo",
     cell: ({ row }) => (
-      <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
+      <Badge
+        variant={row.getValue("active_rider") ? "default" : "secondary"}
+        className="flex items-center gap-1"
+      >
+        {row.getValue("active_rider") ? (
+          <Check className="h-3 w-3" />
+        ) : (
+          <X className="h-3 w-3" />
+        )}
+        {row.getValue("active_rider") ? "Sí" : "No"}
+      </Badge>
     ),
   },
   {

--- a/app/users/[refId]/page.tsx
+++ b/app/users/[refId]/page.tsx
@@ -1,0 +1,114 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams, useRouter } from "next/navigation"
+import { doc, getDoc } from "firebase/firestore"
+import { db } from "@/lib/firebase"
+import { DashboardLayout } from "@/components/layout/dashboard-layout"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import type { User } from "@/lib/types"
+import { ArrowLeft } from "lucide-react"
+
+export default function UserDetailPage() {
+  const params = useParams()
+  const router = useRouter()
+  const refId = decodeURIComponent(params.refId as string)
+
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const snap = await getDoc(doc(db, refId))
+        if (snap.exists()) {
+          const data = snap.data() as User
+          setUser({ ...data, uid: snap.id })
+        }
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    if (refId) fetchUser()
+  }, [refId])
+
+  if (isLoading) {
+    return (
+      <DashboardLayout>
+        <div className="flex items-center justify-center h-64">
+          <LoadingSpinner size="lg" />
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  if (!user) {
+    return (
+      <DashboardLayout>
+        <div className="space-y-6">
+          <div className="flex items-center gap-4">
+            <Button variant="outline" size="icon" onClick={() => router.back()}>
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <h1 className="text-3xl font-bold tracking-tight">Usuario</h1>
+          </div>
+          <p>Usuario no encontrado.</p>
+        </div>
+      </DashboardLayout>
+    )
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="outline" size="icon" onClick={() => router.back()}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">{user.display_name}</h1>
+            <p className="text-muted-foreground">Detalle del usuario</p>
+          </div>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>Información del Usuario</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Email:</span>
+              <span className="text-sm">{user.email}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Rol:</span>
+              <span className="text-sm">{user.role}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-sm font-medium">Activo:</span>
+              <Badge variant={user.isActive ? "default" : "secondary"}>
+                {user.isActive ? "Sí" : "No"}
+              </Badge>
+            </div>
+            {user.createdAt && (
+              <div className="flex justify-between">
+                <span className="text-sm font-medium">Registrado:</span>
+                <span className="text-sm">
+                  {new Date(user.createdAt).toLocaleDateString()}
+                </span>
+              </div>
+            )}
+            {user.address && (
+              <div className="flex justify-between">
+                <span className="text-sm font-medium">Dirección ref:</span>
+                <span className="text-sm">{user.address.path}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </DashboardLayout>
+  )
+}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -1,12 +1,15 @@
 "use client"
 
 import { useEffect } from "react"
+import Link from "next/link"
 import type { ColumnDef } from "@tanstack/react-table"
 import { useUserStore } from "@/lib/stores/useUserStore"
 import { DashboardLayout } from "@/components/layout/dashboard-layout"
 import { DataTable } from "@/components/ui/data-table"
 import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
+import { Eye } from "lucide-react"
 import type { User } from "@/lib/types"
 
 const columns: ColumnDef<User>[] = [
@@ -30,6 +33,20 @@ const columns: ColumnDef<User>[] = [
     cell: ({ row }) => (
       <Badge variant={row.getValue("isActive") ? "default" : "secondary"}>{row.getValue("isActive") ? "Sí" : "No"}</Badge>
     ),
+  },
+  {
+    id: "actions",
+    cell: ({ row }) => {
+      const user = row.original
+      const refId = `users/${user.uid ?? user.id}`
+      return (
+        <Button variant="ghost" size="icon" asChild>
+          <Link href={`/users/${encodeURIComponent(refId)}`}> 
+            <Eye className="h-4 w-4" />
+          </Link>
+        </Button>
+      )
+    },
   },
 ]
 

--- a/lib/services/dashboardService.ts
+++ b/lib/services/dashboardService.ts
@@ -13,8 +13,8 @@ export const getDashboardStats = async (): Promise<DashboardStats> => {
     const activeOrdersSnapshot = await getDocs(activeOrdersQuery)
     const activeOrders = activeOrdersSnapshot.size
 
-    // Get connected riders (assuming riders with isActive=true are connected)
-    const connectedRidersQuery = query(collection(db, "rider"), where("isActive", "==", true))
+    // Get connected riders (assuming riders with active_rider=true are connected)
+    const connectedRidersQuery = query(collection(db, "rider"), where("active_rider", "==", true))
     const connectedRidersSnapshot = await getDocs(connectedRidersQuery)
     const connectedRiders = connectedRidersSnapshot.size
 

--- a/lib/services/riderService.ts
+++ b/lib/services/riderService.ts
@@ -27,7 +27,7 @@ export const getAllRiders = async (): Promise<Rider[]> => {
 
 export const getActiveRiders = async (): Promise<Rider[]> => {
   try {
-    const q = query(collection(db, "rider"), where("isActive", "==", true))
+    const q = query(collection(db, "rider"), where("active_rider", "==", true))
     const ridersSnapshot = await getDocs(q)
     return ridersSnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }) as Rider)
   } catch (error) {

--- a/lib/stores/useRiderStore.ts
+++ b/lib/stores/useRiderStore.ts
@@ -82,8 +82,8 @@ export const useRiderStore = create<RiderState>((set) => ({
               : state.currentRider,
           riders: state.riders.map((r) => (r.id === id ? { ...r, ...data } : r)),
           activeRiders:
-            data.isActive !== undefined
-              ? data.isActive
+            data.active_rider !== undefined
+              ? data.active_rider
                 ? [...state.activeRiders, state.riders.find((r) => r.id === id)!].filter(Boolean)
                 : state.activeRiders.filter((r) => r.id !== id)
               : state.activeRiders,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,7 @@ export interface User {
   role: UserRole
   isActive: boolean
   createdAt: Date
+  address?: DocumentReference
   rider_ref?: DocumentReference
 }
 
@@ -20,7 +21,9 @@ export interface Rider {
   photo_url: string
   user_name: string
   user_ref: DocumentReference
-  isActive?: boolean
+  active_rider: boolean
+  active_orders?: number
+  number_deliverys?: number
 }
 
 export interface Restaurant {


### PR DESCRIPTION
## Summary
- add action column in user list with view button
- support user detail pages under `/users/[refId]`
- include optional `address` field in `User` type

## Testing
- `pnpm install` *(with warnings)*
- `pnpm lint` *(failed: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_684720445948832fadaaafc737aba2d3